### PR TITLE
Added support for device loading and programming through writeSetting()

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,7 @@
 Release 0.3.5 (pending)
 ==========================
 
+- Added settings hooks for device loading and programming
 - Fixed formatting for setGainMode error message
 - Conditional check for bladerf gain mode support
 


### PR DESCRIPTION
Made all the functions in [libbladeRF: Device loading and programming](http://www.nuand.com/libbladeRF-doc/v1.9.0/group___f_n___p_r_o_g.html) available through `writeSetting(key, value)` as discussed in #13.

For example, loading the FPGA can be done by
```python
device.writeSetting("load_fpga", "/path/to/fpga/image");
```