### PR TITLE
libbladerf-v2 fixes

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -63,8 +63,9 @@ bladeRF_SoapySDR::bladeRF_SoapySDR(const bladerf_devinfo &devinfo):
     if (ret == 0) SoapySDR::logf(SOAPY_SDR_INFO, "bladerf_get_serial() = %s", serialStr);
 
     //initialize the sample rates to something
-    this->setSampleRate(SOAPY_SDR_RX, 0, 1e6);
-    this->setSampleRate(SOAPY_SDR_TX, 0, 1e6);
+    this->setSampleRate(SOAPY_SDR_RX, 0, 4e6);
+    this->setSampleRate(SOAPY_SDR_TX, 0, 4e6);
+
 }
 
 bladeRF_SoapySDR::~bladeRF_SoapySDR(void)

--- a/bladeRF_Streaming.cpp
+++ b/bladeRF_Streaming.cpp
@@ -101,7 +101,7 @@ SoapySDR::Stream *bladeRF_SoapySDR::setupStream(
     {
         throw std::runtime_error("setupStream invalid channel selection");
     }
-    const auto layout = _dir2mod(direction, 0);
+    const auto layout = _toch(direction, 0);
     #else
     bladerf_channel_layout layout;
     if (channels.size() == 1 and channels.at(0) == 0)


### PR DESCRIPTION
1e6 sample rate is out of range for bladerf2, causing the libbladerf library to throw an error during init. 4e6 is a friendly value for both bladerf1 and bladerf2 boards.

I don't have a bladeRF1 board to test with and make sure this still works. This documentation indicates that 4e6 is a valid sample rate: https://github.com/Nuand/bladeRF/wiki/Getting-Started:-Verifying-Basic-Device-Operation
 
Follow up to issue #17 .