### PR TITLE
V2 cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,41 +18,17 @@ endif ()
 message(STATUS "LIBBLADERF_INCLUDE_DIRS - ${LIBBLADERF_INCLUDE_DIRS}")
 message(STATUS "LIBBLADERF_LIBRARIES - ${LIBBLADERF_LIBRARIES}")
 
-#version check for recent bladerf with gain mode API
-message(STATUS "Checking for bladerf_set_gain_mode API...")
-message(STATUS "  Reading ${LIBBLADERF_INCLUDE_DIRS}/libbladeRF.h...")
-file(READ ${LIBBLADERF_INCLUDE_DIRS}/libbladeRF.h libbladeRF_h)
-string(FIND "${libbladeRF_h}" "bladerf_gain_mode" has_bladerf_gain_mode)
-if ("${has_bladerf_gain_mode}" STREQUAL "-1")
-    message(STATUS "  libbladeRF no support for bladerf_set_gain_mode API")
-else()
-    add_definitions(-DHAS_BLADERF_GAIN_MODE)
-    message(STATUS "  libbladeRF supports the bladerf_set_gain_mode API")
-endif()
+set(CMAKE_CXX_STANDARD 11)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${LIBBLADERF_INCLUDE_DIRS})
 
-#enable c++11 features
 if(CMAKE_COMPILER_IS_GNUCXX)
-
-    #C++11 is a required language feature for this project
-    include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_STD_CXX11)
-    if(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    else(HAS_STD_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-    endif()
 
     #disable warnings for unused parameters
     add_definitions(-Wno-unused-parameter)
 
 endif(CMAKE_COMPILER_IS_GNUCXX)
-
-if (APPLE)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wc++11-extensions")
-endif(APPLE)
 
 SOAPY_SDR_MODULE_UTIL(
     TARGET bladeRFSupport

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+Release 0.4.1 (pending)
+==========================
+
+- Remove ifdefs for v2 and other version conditionals
+  This is too complicated to maintain across versions.
+
 Release 0.4.0 (2018-12-07)
 ==========================
 

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,11 @@
 Release 0.4.1 (pending)
 ==========================
 
+- Support for MIMO 2x channel streams
+- Added bladerfv2 RSSI and Temperature sensors
+- Added bladerfv2 RFIC register access
+- Switch to name-based register access API
+- Range and gain stage APIs for gain, bandwidth, frequency
 - Remove ifdefs for v2 and other version conditionals
   This is too complicated to maintain across versions.
 

--- a/bladeRF_Registration.cpp
+++ b/bladeRF_Registration.cpp
@@ -2,7 +2,7 @@
  * This file is part of the bladeRF project:
  *   http://www.github.com/nuand/bladeRF
  *
- * Copyright (C) 2015-2017 Josh Blum
+ * Copyright (C) 2015-2018 Josh Blum
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,8 @@ static SoapySDR::Kwargs devinfo_to_kwargs(const bladerf_devinfo &info)
     if (r > 0) args["instance"] = std::string(buff, r);
 
     std::string shortSerial(std::string(info.serial));
-    shortSerial.replace(8, 16, "..");
+    //serial can take the value "ANY" on permissions errors
+    if (shortSerial.size() > 20) shortSerial.replace(8, 16, "..");
     args["label"] = "BladeRF #" + args["instance"] + " [" + shortSerial + "]";
 
     return args;

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -2,7 +2,7 @@
  * This file is part of the bladeRF project:
  *   http://www.github.com/nuand/bladeRF
  *
- * Copyright (C) 2015-2016 Josh Blum
+ * Copyright (C) 2015-2018 Josh Blum
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -47,6 +47,8 @@ bladeRF_SoapySDR::bladeRF_SoapySDR(const bladerf_devinfo &devinfo):
     _timeNsOffset(0),
     _rxBuffSize(0),
     _txBuffSize(0),
+    _rxNumChan(0),
+    _txNumChan(0),
     _rxMinTimeoutMs(0),
     _xb200Mode("disabled"),
     _samplingMode("internal"),

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -25,6 +25,12 @@
 #include <stdexcept>
 #include <cstdio>
 
+//! convert bladerf range to a soapysdr range
+static SoapySDR::Range toRange(const bladerf_range* range)
+{
+    return SoapySDR::Range(range->min*range->scale, range->max*range->scale, range->step*range->scale);
+}
+
 /*******************************************************************
  * Device init/shutdown
  ******************************************************************/
@@ -379,7 +385,7 @@ SoapySDR::Range bladeRF_SoapySDR::getGainRange(const int direction, const size_t
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_gain_range() returned %s", _err2str(ret).c_str());
         throw std::runtime_error("getGainRange()" + _err2str(ret));
     }
-    return SoapySDR::Range(range->min, range->max, range->step);
+    return toRange(range);
 }
 
 SoapySDR::Range bladeRF_SoapySDR::getGainRange(const int direction, const size_t channel, const std::string &name) const
@@ -391,7 +397,7 @@ SoapySDR::Range bladeRF_SoapySDR::getGainRange(const int direction, const size_t
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_gain_stage_range(%s) returned %s", name.c_str(), _err2str(ret).c_str());
         throw std::runtime_error("getGainRange("+name+")" + _err2str(ret));
     }
-    return SoapySDR::Range(range->min, range->max, range->step);
+    return toRange(range);
 }
 
 /*******************************************************************
@@ -445,7 +451,7 @@ SoapySDR::RangeList bladeRF_SoapySDR::getFrequencyRange(const int direction, con
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_frequency_range() returned %s", _err2str(ret).c_str());
         throw std::runtime_error("getFrequencyRange() " + _err2str(ret));
     }
-    return {SoapySDR::Range(range->min, range->max, range->step)};
+    return {toRange(range)};
 }
 
 /*******************************************************************
@@ -509,7 +515,7 @@ SoapySDR::RangeList bladeRF_SoapySDR::getSampleRateRange(const int direction, co
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_sample_rate_range() returned %s", _err2str(ret).c_str());
         throw std::runtime_error("getSampleRateRange() " + _err2str(ret));
     }
-    return {SoapySDR::Range(range->min, range->max, range->step)};
+    return {toRange(range)};
 }
 
 void bladeRF_SoapySDR::setBandwidth(const int direction, const size_t channel, const double bw)
@@ -552,7 +558,7 @@ SoapySDR::RangeList bladeRF_SoapySDR::getBandwidthRange(const int direction, con
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_bandwidth_range() returned %s", _err2str(ret).c_str());
         throw std::runtime_error("getBandwidthRange() " + _err2str(ret));
     }
-    return {SoapySDR::Range(range->min, range->max, range->step)};
+    return {toRange(range)};
 }
 
 /*******************************************************************

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -49,8 +49,6 @@ bladeRF_SoapySDR::bladeRF_SoapySDR(const bladerf_devinfo &devinfo):
     _timeNsOffset(0),
     _rxBuffSize(0),
     _txBuffSize(0),
-    _rxNumChan(0),
-    _txNumChan(0),
     _rxMinTimeoutMs(0),
     _xb200Mode("disabled"),
     _samplingMode("internal"),

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -490,7 +490,7 @@ void bladeRF_SoapySDR::setSampleRate(const int direction, const size_t channel, 
     //restore the previous hardware time setting (after rate stash)
     this->setHardwareTime(timeNow);
 
-    SoapySDR::logf(SOAPY_SDR_INFO, "setSampleRate(%d, %f MHz), actual = %f MHz", direction, rate/1e6, actual/1e6);
+    SoapySDR::logf(SOAPY_SDR_INFO, "setSampleRate(%s, %d, %f MHz), actual = %f MHz", direction==SOAPY_SDR_RX?"Rx":"Tx", int(channel), rate/1e6, actual/1e6);
 }
 
 double bladeRF_SoapySDR::getSampleRate(const int direction, const size_t channel) const

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -347,8 +347,8 @@ private:
     int16_t *_txConvBuff;
     size_t _rxBuffSize;
     size_t _txBuffSize;
-    size_t _rxNumChan;
-    size_t _txNumChan;
+    std::vector<size_t> _rxChans;
+    std::vector<size_t> _txChans;
     long _rxMinTimeoutMs;
     std::queue<StreamMetadata> _rxCmds;
     std::queue<StreamMetadata> _txResps;

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -221,12 +221,29 @@ public:
     void setHardwareTime(const long long timeNs, const std::string &what = "");
 
     /*******************************************************************
-     * Register API
+     * Sensor API
      ******************************************************************/
 
-    void writeRegister(const unsigned addr, const unsigned value);
+    std::vector<std::string> listSensors(void) const;
 
-    unsigned readRegister(const unsigned addr) const;
+    SoapySDR::ArgInfo getSensorInfo(const std::string &key) const;
+
+    std::string readSensor(const std::string &key) const;
+
+    std::vector<std::string> listSensors(const int direction, const size_t channel) const;
+
+    SoapySDR::ArgInfo getSensorInfo(const int direction, const size_t channel, const std::string &key) const;
+
+    std::string readSensor(const int direction, const size_t channel, const std::string &key) const;
+
+    /*******************************************************************
+     * Register API
+     ******************************************************************/
+    std::vector<std::string> listRegisterInterfaces(void) const;
+
+    void writeRegister(const std::string &name, const unsigned addr, const unsigned value);
+
+    unsigned readRegister(const std::string &name, const unsigned addr) const;
 
     /*******************************************************************
      * Settings API
@@ -315,6 +332,7 @@ private:
         _rxMinTimeoutMs = long((2*1000*_rxBuffSize)/_rxSampRate);
     }
 
+    bool _isBladeRF1;
     double _rxSampRate;
     double _txSampRate;
     bool _inTxBurst;

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -2,7 +2,7 @@
  * This file is part of the bladeRF project:
  *   http://www.github.com/nuand/bladeRF
  *
- * Copyright (C) 2015-2016 Josh Blum
+ * Copyright (C) 2015-2018 Josh Blum
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -328,6 +328,8 @@ private:
     int16_t *_txConvBuff;
     size_t _rxBuffSize;
     size_t _txBuffSize;
+    size_t _rxNumChan;
+    size_t _txNumChan;
     long _rxMinTimeoutMs;
     std::queue<StreamMetadata> _rxCmds;
     std::queue<StreamMetadata> _txResps;

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -333,6 +333,7 @@ private:
     }
 
     bool _isBladeRF1;
+    bool _isBladeRF2;
     double _rxSampRate;
     double _txSampRate;
     bool _inTxBurst;

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -178,6 +178,8 @@ public:
 
     double getGain(const int direction, const size_t channel, const std::string &name) const;
 
+    SoapySDR::Range getGainRange(const int direction, const size_t channel) const;
+
     SoapySDR::Range getGainRange(const int direction, const size_t channel, const std::string &name) const;
 
     /*******************************************************************

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -28,11 +28,8 @@
 #include <queue>
 
 #if defined(LIBBLADERF_API_VERSION) && (LIBBLADERF_API_VERSION >= 0x02000000)
-#define LIBBLADERF_V2
-#endif
-
-#ifndef LIBBLADERF_V2
-typedef unsigned int bladerf_frequency;
+#else
+#error "Requires libladerfv2!"
 #endif
 
 /*!
@@ -259,17 +256,10 @@ public:
 
 private:
 
-    #ifndef LIBBLADERF_V2
-    static bladerf_module _toch(const int direction, const size_t)
-    {
-        return (direction == SOAPY_SDR_RX)?BLADERF_MODULE_RX:BLADERF_MODULE_TX;
-    }
-    #else
     static bladerf_channel _toch(const int direction, const size_t channel)
     {
         return (direction == SOAPY_SDR_RX)?BLADERF_CHANNEL_RX(channel):BLADERF_CHANNEL_TX(channel);
     }
-    #endif
 
     static std::string _err2str(const int err)
     {

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -200,13 +200,13 @@ public:
 
     double getSampleRate(const int direction, const size_t channel) const;
 
-    std::vector<double> listSampleRates(const int direction, const size_t channel) const;
+    SoapySDR::RangeList getSampleRateRange(const int direction, const size_t channel) const;
 
     void setBandwidth(const int direction, const size_t channel, const double bw);
 
     double getBandwidth(const int direction, const size_t channel) const;
 
-    std::vector<double> listBandwidths(const int direction, const size_t channel) const;
+    SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const;
 
     /*******************************************************************
      * Time API

--- a/bladeRF_Streaming.cpp
+++ b/bladeRF_Streaming.cpp
@@ -96,13 +96,6 @@ SoapySDR::Stream *bladeRF_SoapySDR::setupStream(
     if (channels.empty()) channels.push_back(0);
 
     //check the channel configuration
-    #ifndef LIBBLADERF_V2
-    if (channels.size() > 1 or (channels.size() > 0 and channels.at(0) != 0))
-    {
-        throw std::runtime_error("setupStream invalid channel selection");
-    }
-    const auto layout = _toch(direction, 0);
-    #else
     bladerf_channel_layout layout;
     if (channels.size() == 1 and channels.at(0) == 0)
     {
@@ -116,7 +109,6 @@ SoapySDR::Stream *bladeRF_SoapySDR::setupStream(
     {
         throw std::runtime_error("setupStream invalid channel selection");
     }
-    #endif
 
     //check the format
     if (format == "CF32") {}
@@ -404,11 +396,7 @@ int bladeRF_SoapySDR::writeStream(
         else
         {
             md.flags |= BLADERF_META_FLAG_TX_NOW;
-            #ifndef LIBBLADERF_V2
-            bladerf_get_timestamp(_dev, BLADERF_MODULE_TX, &md.timestamp);
-            #else
             bladerf_get_timestamp(_dev, BLADERF_TX, &md.timestamp);
-            #endif
         }
         _txNextTicks = md.timestamp;
     }


### PR DESCRIPTION
It was getting difficult to maintain backwards compatibility with the v1 API. Actually it didnt compile. This commit removes all of the ifdefs and makes use of new bladerf APIs to fetch ranges and settings (vs hw specific macros).

* resolves https://github.com/pothosware/SoapyBladeRF/issues/22
* resolves https://github.com/pothosware/SoapyBladeRF/issues/20