### PR TITLE
Fixes for Cubic compatibility

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -302,11 +302,17 @@ bool bladeRF_SoapySDR::hasGainMode(const int direction, const size_t channel) co
             return false;
         }
 
-        ret = bladerf_set_gain_mode(_dev, _toch(direction, channel), mode);
+		/* Test if it will take automatic mode */
+        ret = bladerf_set_gain_mode(_dev, _toch(direction, channel), BLADERF_GAIN_AUTOMATIC);
         if (ret != 0) {
             return false;
         }
 
+		/* We're good - restore it to the original mode */
+		ret = bladerf_set_gain_mode(_dev, _toch(direction, channel), mode);
+        if (ret != 0) {
+            return false;
+        }
         return true;
     }
 }

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -536,6 +536,17 @@ SoapySDR::RangeList bladeRF_SoapySDR::getSampleRateRange(const int direction, co
     return {toRange(range)};
 }
 
+std::vector<double> bladeRF_SoapySDR::listSampleRates(const int, const size_t channel) const
+{
+    std::vector<double> options;
+    for (double r = 160e3; r <= 200e3; r += 40e3) options.push_back(r);
+    for (double r = 300e3; r <= 900e3; r += 100e3) options.push_back(r);
+    for (double r = 1e6; r <= 40e6; r += 1e6) options.push_back(r);
+    //options.push_back(BLADERF_SAMPLERATE_MIN);
+    //options.push_back(BLADERF_SAMPLERATE_REC_MAX);
+    return options;
+}
+
 void bladeRF_SoapySDR::setBandwidth(const int direction, const size_t channel, const double bw)
 {
     //bypass the filter when sufficiently large BW is selected
@@ -578,6 +589,32 @@ SoapySDR::RangeList bladeRF_SoapySDR::getBandwidthRange(const int direction, con
     }
     return {toRange(range)};
 }
+
+std::vector<double> bladeRF_SoapySDR::listBandwidths(const int, const size_t) const
+{
+    std::vector<double> options;
+    options.push_back(0.75);
+    options.push_back(0.875);
+    options.push_back(1.25);
+    options.push_back(1.375);
+    options.push_back(1.5);
+    options.push_back(1.92);
+    options.push_back(2.5);
+    options.push_back(2.75);
+    options.push_back(3);
+    options.push_back(3.5);
+    options.push_back(4.375);
+    options.push_back(5);
+    options.push_back(6);
+    options.push_back(7);
+    options.push_back(10);
+    options.push_back(14);
+    for (size_t i = 0; i < options.size(); i++) options[i] *= 2e6;
+    //options.push_back(BLADERF_BANDWIDTH_MIN);
+    //options.push_back(BLADERF_BANDWIDTH_MAX);
+    return options;
+}
+
 
 /*******************************************************************
  * Time API

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -288,7 +288,27 @@ std::complex<double> bladeRF_SoapySDR::getIQBalance(const int direction, const s
 
 bool bladeRF_SoapySDR::hasGainMode(const int direction, const size_t channel) const
 {
-    return _toch(direction, channel) == BLADERF_CHANNEL_RX(channel) ? true : false;
+    if (_toch(direction, channel) != BLADERF_CHANNEL_RX(channel)) {
+        return false;
+    } else {
+        /* This actually depends on a lot of things, including presence of a LUT
+         * table, so best to determine dynamically.
+         */
+        bladerf_gain_mode mode;
+        int ret;
+
+        ret = bladerf_get_gain_mode(_dev, _toch(direction, channel), &mode);
+        if (ret != 0) {
+            return false;
+        }
+
+        ret = bladerf_set_gain_mode(_dev, _toch(direction, channel), mode);
+        if (ret != 0) {
+            return false;
+        }
+
+        return true;
+    }
 }
 
 void bladeRF_SoapySDR::setGainMode(const int direction, const size_t channel, const bool automatic)

--- a/bladeRF_SoapySDR.hpp
+++ b/bladeRF_SoapySDR.hpp
@@ -202,6 +202,8 @@ public:
 
     double getSampleRate(const int direction, const size_t channel) const;
 
+	std::vector<double> listSampleRates(const int direction, const size_t channel) const;
+
     SoapySDR::RangeList getSampleRateRange(const int direction, const size_t channel) const;
 
     void setBandwidth(const int direction, const size_t channel, const double bw);
@@ -209,6 +211,8 @@ public:
     double getBandwidth(const int direction, const size_t channel) const;
 
     SoapySDR::RangeList getBandwidthRange(const int direction, const size_t channel) const;
+
+	std::vector<double> listBandwidths(const int direction, const size_t channel) const;
 
     /*******************************************************************
      * Time API


### PR DESCRIPTION
listSampleRates and listBandwidths have been re-added, since it seems most proper for the Soapy module to provide these lists as device-specific recommendations, rather than having any higher level applications derive recommendations from a range.

Additionally, hasGainMode really tries its best to figure out if AGC is available. If not, it returns false so that hasGainMode can be used as a safeguard before a (potentially failing) call to setGainMode.