### PR TITLE
Use the full range for the CS16 data type

### DIFF
--- a/bladeRF_Streaming.cpp
+++ b/bladeRF_Streaming.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> bladeRF_SoapySDR::getStreamFormats(const int, const siz
 
 std::string bladeRF_SoapySDR::getNativeStreamFormat(const int, const size_t, double &fullScale) const
 {
-    fullScale = 2048;
+    fullScale = 32768;
     return "CS16";
 }
 


### PR DESCRIPTION
The driver currently expects samples in the bladerf's native range of -2048-2047 when using the CS16 data type. This patch fixes this by adding a simple bit shift on RX and TX.

I'm only able to test the changes in writeStream() at the moment (with hacktv), I've no handy way of testing readStream().