### PR TITLE
enable channels in constructor, not stream

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,8 @@
+Release 0.4.2 (pending)
+==========================
+
+- Enable channels in the constructor
+
 Release 0.4.1 (2019-01-26)
 ==========================
 

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -73,6 +73,18 @@ bladeRF_SoapySDR::bladeRF_SoapySDR(const bladerf_devinfo &devinfo):
     ret = bladerf_get_serial_struct(_dev, &serial);
     if (ret == 0) SoapySDR::logf(SOAPY_SDR_INFO, "bladerf_get_serial() = %s", serial.serial);
 
+    //enable channels
+    for (size_t ch = 0; ch < this->getNumChannels(SOAPY_SDR_RX); ch++)
+    {
+        auto ret = bladerf_enable_module(_dev, _toch(SOAPY_SDR_RX, ch), true);
+        if (ret != 0) SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(rx, true) returned %d", ret);
+    }
+    for (size_t ch = 0; ch < this->getNumChannels(SOAPY_SDR_TX); ch++)
+    {
+        auto ret = bladerf_enable_module(_dev, _toch(SOAPY_SDR_TX, ch), true);
+        if (ret != 0) SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(tx, true) returned %d", ret);
+    }
+
     //initialize the sample rates to something
     this->setSampleRate(SOAPY_SDR_RX, 0, 4e6);
     this->setSampleRate(SOAPY_SDR_TX, 0, 4e6);
@@ -80,6 +92,18 @@ bladeRF_SoapySDR::bladeRF_SoapySDR(const bladerf_devinfo &devinfo):
 
 bladeRF_SoapySDR::~bladeRF_SoapySDR(void)
 {
+    //disable channels
+    for (size_t ch = 0; ch < this->getNumChannels(SOAPY_SDR_RX); ch++)
+    {
+        auto ret = bladerf_enable_module(_dev, _toch(SOAPY_SDR_RX, ch), false);
+        if (ret != 0) SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(rx, false) returned %d", ret);
+    }
+    for (size_t ch = 0; ch < this->getNumChannels(SOAPY_SDR_TX); ch++)
+    {
+        auto ret = bladerf_enable_module(_dev, _toch(SOAPY_SDR_TX, ch), false);
+        if (ret != 0) SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(tx, false) returned %d", ret);
+    }
+
     SoapySDR::logf(SOAPY_SDR_INFO, "bladerf_close()");
     if (_dev != NULL) bladerf_close(_dev);
 }

--- a/bladeRF_Streaming.cpp
+++ b/bladeRF_Streaming.cpp
@@ -144,17 +144,6 @@ SoapySDR::Stream *bladeRF_SoapySDR::setupStream(
         throw std::runtime_error("setupStream() " + _err2str(ret));
     }
 
-    //enable channels used in streaming
-    for (const auto ch : channels)
-    {
-        ret = bladerf_enable_module(_dev, _toch(direction, ch), true);
-        if (ret != 0)
-        {
-            SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(true) returned %d", ret);
-            throw std::runtime_error("setupStream() " + _err2str(ret));
-        }
-    }
-
     if (direction == SOAPY_SDR_RX)
     {
         _rxOverflow = false;
@@ -180,17 +169,6 @@ void bladeRF_SoapySDR::closeStream(SoapySDR::Stream *stream)
 {
     const int direction = *reinterpret_cast<int *>(stream);
     auto &chans = (direction == SOAPY_SDR_RX)?_rxChans:_txChans;
-
-    //deactivate the stream here -- only call once
-    for (const auto ch : chans)
-    {
-        const int ret = bladerf_enable_module(_dev, _toch(direction, ch), false);
-        if (ret != 0)
-        {
-            SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_enable_module(false) returned %s", _err2str(ret).c_str());
-            throw std::runtime_error("closeStream() " + _err2str(ret));
-        }
-    }
     chans.clear();
 
     //cleanup stream convert buffers


### PR DESCRIPTION
this may affect certain settings to not have channels enabled at init time. This should fix some issues with setting the gain.

* resolves https://github.com/pothosware/SoapyBladeRF/issues/30