### PR TITLE
added flags for BLADERF_META_FLAG_RX_HW_MINIEXP1&2

### DIFF
--- a/bladeRF_Streaming.cpp
+++ b/bladeRF_Streaming.cpp
@@ -391,6 +391,10 @@ int bladeRF_SoapySDR::readStream(
         _rxOverflow = true;
     }
 
+    //add flags specific to BladeRF from bladerf_sync_rx.status.
+    if ((md.status & BLADERF_META_FLAG_RX_HW_MINIEXP1) != 0) flags |= SOAPY_SDR_USER_FLAG0;
+    if ((md.status & BLADERF_META_FLAG_RX_HW_MINIEXP2) != 0) flags |= SOAPY_SDR_USER_FLAG1;
+
     //consume from the command if this is a finite burst
     if (cmd.numElems > 0)
     {


### PR DESCRIPTION
Those 2 flags are surfaced with SOAPY_SDR_USER_FLAG0 and SOAPY_SDR_USER_FLAG1.

See https://github.com/pothosware/SoapyBladeRF/issues/31#issuecomment-531077320