### PR TITLE
feat: allow turning bias tee off

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -1507,9 +1507,9 @@ void bladeRF_SoapySDR::writeSetting(const std::string &key, const std::string &v
     }
     else if (key == "biastee_tx")
     {
-        if (value == "true") {
+        if (value == "true" || value == "false") {
             // --> Valid setting has arrived
-            int ret = bladerf_set_bias_tee(_dev, BLADERF_CHANNEL_TX(0), true);
+            int ret = bladerf_set_bias_tee(_dev, BLADERF_CHANNEL_TX(0), value == "true");
             if (ret != 0)
             {
                 SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_set_bias_tee(BLADERF_CHANNEL_TX(0), %s) returned %s",
@@ -1521,9 +1521,9 @@ void bladeRF_SoapySDR::writeSetting(const std::string &key, const std::string &v
     }
     else if (key == "biastee_rx")
     {
-        if (value == "true") {
+        if (value == "true" || value == "false") {
             // --> Valid setting has arrived
-            int ret = bladerf_set_bias_tee(_dev, BLADERF_CHANNEL_RX(0), true);
+            int ret = bladerf_set_bias_tee(_dev, BLADERF_CHANNEL_RX(0), value == "true");
             if (ret != 0)
             {
                 SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_set_bias_tee(BLADERF_CHANNEL_RX(0), %s) returned %s",


### PR DESCRIPTION
It's currently possible to turn the bias tee on for RX and TX, but not off.

I followed the current code and just added the possibility to pass `"false"` instead of just `"true"` for `"biastee_rx"` and `"biastee_tx"`.