### PR TITLE
print gain mode on config

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -327,6 +327,23 @@ void bladeRF_SoapySDR::setGainMode(const int direction, const size_t channel, co
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_set_gain_mode(%s) returned %s", automatic?"automatic":"manual", _err2str(ret).c_str());
         throw std::runtime_error("setGainMode() " + _err2str(ret));
     }
+    bladerf_gain_mode return_mode;
+    bladerf_get_gain_mode(_dev, _toch(direction, channel), &return_mode);
+    std::string gain_mode_string;
+
+    if (return_mode == BLADERF_GAIN_DEFAULT) {
+        gain_mode_string = "default";
+    } else if (return_mode == BLADERF_GAIN_MGC) {
+        gain_mode_string = "manual";
+    } else if (return_mode == BLADERF_GAIN_FASTATTACK_AGC) {
+        gain_mode_string = "fastattack";
+    } else if (return_mode == BLADERF_GAIN_SLOWATTACK_AGC) {
+        gain_mode_string = "slowattack";
+    } else if (return_mode == BLADERF_GAIN_HYBRID_AGC) {
+        gain_mode_string = "hybrid";
+    }
+
+    SoapySDR::logf(SOAPY_SDR_INFO, "setGainMode(%s, %d, %d), actual = %s", direction==SOAPY_SDR_RX?"Rx":"Tx", int(channel), automatic, gain_mode_string.c_str());
 }
 
 bool bladeRF_SoapySDR::getGainMode(const int direction, const size_t channel) const

--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -341,6 +341,8 @@ void bladeRF_SoapySDR::setGainMode(const int direction, const size_t channel, co
         gain_mode_string = "slowattack";
     } else if (return_mode == BLADERF_GAIN_HYBRID_AGC) {
         gain_mode_string = "hybrid";
+    } else {
+        gain_mode_string = "<unknown>";
     }
 
     SoapySDR::logf(SOAPY_SDR_INFO, "setGainMode(%s, %d, %d), actual = %s", direction==SOAPY_SDR_RX?"Rx":"Tx", int(channel), automatic, gain_mode_string.c_str());


### PR DESCRIPTION
Newer BladeRF boards have different gain settings. For example, the xA4 no longer has separate control for VGA/LNA. Furthermore, the default gain control mode is different on these new boards; there is more variability in what "AGC" means, which is breaking the SoapySDR logic to check for whether AGC is enabled. This change will now print the actual gain mode when it's set so users don't have to guess which gain control mode they are using on their board.