### PR TITLE
Update bladeRF_SoapySDR::getGainMode to check not for BLADERF_GAIN_AUTOMATIC but that value is not BLADERF_GAIN_MANAUL

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -358,7 +358,7 @@ bool bladeRF_SoapySDR::getGainMode(const int direction, const size_t channel) co
         SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_gain_mode() returned %s", _err2str(ret).c_str());
         throw std::runtime_error("getGainMode() " + _err2str(ret));
     }
-    return gain_mode == BLADERF_GAIN_AUTOMATIC;
+    return gain_mode != BLADERF_GAIN_MANUAL;
 }
 
 std::vector<std::string> bladeRF_SoapySDR::listGains(const int direction, const size_t channel) const


### PR DESCRIPTION
The current issue with BladeRF 2.0 is that when `setGainMode` is set to `automatic`, reading the value back returns `false`.

This occurs because BladeRF supports multiple automatic gain modes, but the current implementation represents them as a single boolean value. As a result, the readback does not accurately reflect the configured automatic mode, causing the check to return `false`.