### PR TITLE
Fix biastee settings to return actual device state

### DIFF
--- a/bladeRF_Settings.cpp
+++ b/bladeRF_Settings.cpp
@@ -1231,9 +1231,25 @@ std::string bladeRF_SoapySDR::readSetting(const std::string &key) const
     } else if (key == "load_fpga") {
         return "";
     } else if (key == "biastee_tx") {
-        return "false";
+      bool enabled;
+      int ret = bladerf_get_bias_tee(_dev, BLADERF_CHANNEL_TX(0), &enabled);
+      if (ret != 0)
+      {
+        SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_bias_tee(BLADERF_CHANNEL_TX(0)) returned %s",
+                       _err2str(ret).c_str());
+        throw std::runtime_error("readSetting() " + _err2str(ret));
+      }
+      return enabled ? "true" : "false";
     } else if (key == "biastee_rx") {
-        return "false";
+      bool enabled;
+      int ret = bladerf_get_bias_tee(_dev, BLADERF_CHANNEL_RX(0), &enabled);
+      if (ret != 0)
+      {
+        SoapySDR::logf(SOAPY_SDR_ERROR, "bladerf_get_bias_tee(BLADERF_CHANNEL_RX(0)) returned %s",
+                       _err2str(ret).c_str());
+        throw std::runtime_error("readSetting() " + _err2str(ret));
+      }
+      return enabled ? "true" : "false";
     }
 
     SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());


### PR DESCRIPTION
This PR replaces the static `"false"` return values for `biastee_tx` and
`biastee_rx` in `readSetting()` with calls to `bladerf_get_bias_tee()`.

### Changes
- Query the device for the current bias tee state on both TX and RX channels
- Return `"true"` or `"false"` based on the actual hardware state
- Add error handling and logging when `bladerf_get_bias_tee()` fails

### Why
Previously, these settings always returned `"false"`, regardless of the
actual hardware configuration. This resulted in incorrect state reporting
to users and higher-level applications.

### Impact
- Fixes incorrect behavior in settings reporting
- Aligns `readSetting()` with real device state
- Improves reliability for applications relying on bias tee status